### PR TITLE
Updating mpich to build from cache and use more versions

### DIFF
--- a/.github/workflows/deploy-test-containers.yaml
+++ b/.github/workflows/deploy-test-containers.yaml
@@ -9,9 +9,6 @@ jobs:
     if: ${{ github.event.label.name == 'deploy-test-container' }}
     runs-on: ubuntu-latest
     name: List Tests
-    steps:
-
-    runs-on: ubuntu-latest
     outputs:
       tests: ${{ steps.list.outputs.tests }}
     steps:

--- a/build-si-containers
+++ b/build-si-containers
@@ -102,7 +102,7 @@ class TestPackage:
         jsonschema.validate(self.config, schema=config_schema)
 
     def __getattr__(self, key):
-        return self.config['package'].get(key)
+        return self.config['package'].get(key) or self.config.get(key)
 
 
 class TestSetup:
@@ -201,7 +201,7 @@ class TestSetup:
         # Create the package to test
         package_file = self.get_package_config(package)
         package = TestPackage(package_file)
-
+        
         # Return a list of containers build to test later
         containers = []
 
@@ -209,7 +209,7 @@ class TestSetup:
         for tester in self.testers:
 
             # Get the tester build template
-            template = self.get_tester_template(tester, use_cache)
+            template = self.get_tester_template(tester, package.test['build_cache'] or use_cache)
             tester = Tester(self.get_tester_config(tester))
 
             # Right now one container has all versions
@@ -236,6 +236,9 @@ class TestSetup:
             if container_name in skips:
                 containers.append(container_name)
                 continue
+
+            # Show dockerfile to the user
+            print("Dockerfile:---------\n%s\n" % out)
 
             with tempfile.TemporaryDirectory() as tmp:
                 write_file(out, os.path.join(tmp, "Dockerfile"))

--- a/templates/libabigail/runtests.py
+++ b/templates/libabigail/runtests.py
@@ -38,9 +38,9 @@ def run(cmd):
     """
     Run a command with os.system
     """
-    print(cmd)
-    os.system(cmd)
-
+    if cmd:
+        print(cmd)
+        os.system(cmd)
 
 def main():
     """

--- a/templates/libabigail/runtests.py
+++ b/templates/libabigail/runtests.py
@@ -107,6 +107,8 @@ def main():
 
                 out_file = "/results/{{ tester.name }}/{{ tester.version }}/{{ package.name }}/compat/%s-%s" % (spec_version, spec2_version)
                 create_outdir(out_file)
+                
+                # Important! This requires debug sumbols, so we allow to fail since most don't have
                 run("time -p abicompat %s %s %s > %s > %s.log" % (bin1, lib, lib2, out_file, out_file))
                 {% endfor %}
         {% endfor %}

--- a/tests/mpich.yaml
+++ b/tests/mpich.yaml
@@ -1,13 +1,10 @@
 package:
  name: mpich
  versions:
-# versions will be used when we add a build cache, for now they are 
-# discovered in the autamus base container ghcr.io/autamus/buildsi-mpich
-  - "3.2.1 device=ch3 netmod=tcp"
-#  - "3.2.1"
-#  - "3.3"
-#  - "3.3.2"
-#  - "2-1.5"
+  - "3.4.1"
+  - "3.3.2"
+  - "3.1.4 device=ch3 netmod=tcp"
+  - "3.0.4 device=ch3 netmod=tcp"
  headers:
   - include
  libs:
@@ -23,4 +20,5 @@ package:
    - share/mpich/src/examples/cpi
 
 test:
+  # Always use the build cache instead of prebuilt container
   build_cache: true


### PR DESCRIPTION
We still do not have debug symbols so the abicompat commands will fail, but at least this gives us the start to defining our testing cases.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>