### PR TITLE
Trigger re-run of ben tests, some results missing

### DIFF
--- a/tests/libabigail-test-ben.yaml
+++ b/tests/libabigail-test-ben.yaml
@@ -1,5 +1,4 @@
 packages:
- # no versions specified implies all
  - name: ben
 
 tester:


### PR DESCRIPTION
I think the result files for compat aren't showing up because they are missing, but I want to run once more just to double check!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>