### PR TITLE
Allowing for tests to specify specific versions of testers

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,23 @@ experiment:
 ```
 
 The dockerfile should always be in the context of the [templates](templates)
-directory.
+directory. If you want to pin the test to use a specific version of the tester,
+then you can do the following:
+
+```
+packages:
+ - name: ben
+
+tester:
+  name: smeagle
+  version: 0.0.11
+
+experiment:
+  name: single-test  
+```
+
+This will only work for the default Dockerfile templates - if you want to use
+the test variable here, then you'll need reference `{{ test.version }}`.
  
 ### Reproduce a Test
 

--- a/build-si-containers
+++ b/build-si-containers
@@ -78,6 +78,7 @@ test_schema = {
     "title": "build-abi-containers test schema",
     "type": "object",
     "additionalProperties": False,
+    "requiredProperties": ["packages", "experiment", "tester"],
     "properties": {
         "packages": {
             "type": "array",
@@ -110,6 +111,7 @@ test_schema = {
                     "type": "string",
                     "enum": ["libabigail", "symbolator", "smeagle"],
                 },
+                "version": {"type": ["string"]},
             },
         },
         "test": {
@@ -206,6 +208,13 @@ class Test(Config):
         for term in ["prebuilt", "use_cache"]:
             if term in kwargs:
                 self.config["test"][term] = kwargs.get(term)
+
+    @property
+    def version(self):
+        """
+        If the test tester has a version, return it
+        """
+        return self.config["tester"].get("version")
 
     def __str__(self):
         return "<test:%s>" % os.path.basename(self.config_file)

--- a/templates/Dockerfile.buildcache
+++ b/templates/Dockerfile.buildcache
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y curl python3-botocore python3-boto3 && 
     {% for package in packages %}{% for version in package.versions %}spack install --source {% if cache_only %}--cache-only{% endif %} {{ package.name }}@{{ version }} && \{% endfor %}{% endfor %}
     printf "Finished installation attempts\n"
 
-FROM {% if tester.container %}{{ tester.container }}{% else %}ghcr.io/buildsi/{{ tester.name }}{% endif %}:{{ tester.version }}
+FROM {% if tester.container %}{{ tester.container }}{% else %}ghcr.io/buildsi/{{ tester.name }}{% endif %}:{% if test.version %}{{ test.version }}{% else %}{{ tester.version }}{% endif %}
 COPY --from=base /opt/spack /opt/spack
 
 WORKDIR /build-si/

--- a/templates/Dockerfile.default
+++ b/templates/Dockerfile.default
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y curl python3-botocore python3-boto3 && 
     {% for package in packages %}{% for version in package.versions %}spack install --no-checksum --source {% if cache_only %}--cache-only{% endif %} --deprecated {{ package.name }}@{{ version }} && \{% endfor %}{% endfor %}
     printf "Finished installation attempts\n"
 
-FROM {% if tester.container %}{{ tester.container }}{% else %}ghcr.io/buildsi/{{ tester.name }}{% endif %}:{{ tester.version }}
+FROM {% if tester.container %}{{ tester.container }}{% else %}ghcr.io/buildsi/{{ tester.name }}{% endif %}:{% if test.version %}{{ test.version }}{% else %}{{ tester.version }}{% endif %}
 COPY --from=base /opt/spack /opt/spack
 
 WORKDIR /build-si/

--- a/tests/smeagle-test-ben.yaml
+++ b/tests/smeagle-test-ben.yaml
@@ -4,6 +4,7 @@ packages:
 
 tester:
   name: smeagle
+  version: 0.0.11
 
 test:
   dockerfile: templates/ben/Dockerfile


### PR DESCRIPTION
this will allow us to easily trigger tests to run for updated versions of testers. E.g., I would just change:

```yaml
tester:
  name: smeagle
  version: 0.0.11
```
to

```yaml
tester:
  name: smeagle
  version: 0.0.12
```

The results are organized by version so we would keep both, and it just comes down to keeping track of what recent version we are using here.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>